### PR TITLE
feat: add delayed autofocus option

### DIFF
--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -44,3 +44,65 @@ export const Primary: StoryFn<typeof MuiOtpInput> = () => {
     </ThemeProvider>
   )
 }
+
+export const DelayedAutoFocus: StoryFn<typeof MuiOtpInput> = () => {
+  const [value, setValue] = React.useState<string>('')
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue)
+  }
+
+  const handleComplete = (finalValue: string) => {
+    action('onComplete')(finalValue)
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div>
+        <p style={{ marginBottom: 16 }}>
+          This input will focus automatically after 200ms delay
+        </p>
+        <MuiOtpInput
+          length={6}
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus={200}
+          sx={{ width: 350 }}
+          gap={1}
+          onComplete={handleComplete}
+          value={value}
+          onChange={handleChange}
+        />
+      </div>
+    </ThemeProvider>
+  )
+}
+
+export const NoAutoFocus: StoryFn<typeof MuiOtpInput> = () => {
+  const [value, setValue] = React.useState<string>('')
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue)
+  }
+
+  const handleComplete = (finalValue: string) => {
+    action('onComplete')(finalValue)
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div>
+        <p style={{ marginBottom: 16 }}>This input has no autofocus</p>
+        <MuiOtpInput
+          length={4}
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus={false}
+          sx={{ width: 250 }}
+          gap={1}
+          onComplete={handleComplete}
+          value={value}
+          onChange={handleChange}
+        />
+      </div>
+    </ThemeProvider>
+  )
+}

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { expect, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
 import { MuiOtpInput } from './index'
 import * as testUtils from './testUtils'
 import '@testing-library/jest-dom/vitest'
@@ -45,5 +45,24 @@ describe('components/MuiOtpInput', () => {
     // eslint-disable-next-line jsx-a11y/no-autofocus
     render(<MuiOtpInput value="abcd" autoFocus />)
     expect(testUtils.getInputElementByIndex(0)).toHaveFocus()
+  })
+
+  test('should focus first input with delay when autoFocus is a number', () => {
+    vi.useFakeTimers()
+    // eslint-disable-next-line jsx-a11y/no-autofocus
+    render(<MuiOtpInput value="abcd" autoFocus={100} />)
+
+    // Initially, the first input should not have focus
+    expect(testUtils.getInputElementByIndex(0)).not.toHaveFocus()
+
+    // Advance timers by 100ms to trigger the setTimeout callback
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    // Now the first input should have focus
+    expect(testUtils.getInputElementByIndex(0)).toHaveFocus()
+
+    vi.useRealTimers()
   })
 })

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -6,12 +6,18 @@ type TextFieldProps = Omit<
   'onChange' | 'select' | 'multiline' | 'defaultValue' | 'value' | 'autoFocus'
 >
 
-type BoxProps = Omit<MuiBoxProps, 'onChange' | 'onBlur'>
+type BoxProps = Omit<MuiBoxProps, 'onChange' | 'onBlur' | 'autoFocus'>
 
 export interface BaseMuiOtpInputProps {
   value?: string
   length?: number
-  autoFocus?: boolean
+  /**
+   * Controls autofocus behavior for the first input field.
+   * - `true`: Focus immediately on mount
+   * - `false`: No autofocus (default)
+   * - `number`: Delay in milliseconds before focusing
+   */
+  autoFocus?: boolean | number
   TextFieldsProps?: TextFieldProps | ((index: number) => TextFieldProps)
   onComplete?: (value: string) => void
   validateChar?: (character: string, index: number) => boolean


### PR DESCRIPTION
## Summary
- Added support for delayed autofocus with `autoFocus` prop accepting `boolean | number`
- Number value sets delay in milliseconds before focusing the first input
- Maintains full backward compatibility with existing boolean behavior

## Changes
- Updated `autoFocus` type definition to `boolean | number`
- Implemented `setTimeout` logic for delayed focus
- Fixed refs stability issue with `useMemo`
- Added tests for delayed autofocus functionality
- Added Storybook examples demonstrating the feature

## Test plan
- [x] All existing tests pass
- [x] New tests for delayed autofocus added
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] Manual testing in Storybook